### PR TITLE
Add autoclose property to the IsometricPath class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [3.2.0] - 2021-12-28
+
+- Added a property to close automatically or not the `IsometricPath`
+
 ## [3.1.1] - 2021-12-22
 
 - Removed comments from the bundles

--- a/README.md
+++ b/README.md
@@ -725,6 +725,7 @@ const path = new IsometricPath([properties]);
 | strokeLinejoin  | string             | "round"        | Sets the [SVG stroke linejoin][3] of the isometric path  |
 | strokeWidth     | number             | 1              | Sets the stroke width of the isometric path              |
 | texture         | Texture (`object`) | -              | Sets the texture of the isometric path                   |
+| autoclose       | boolean            | true           | Sets if the path should close automatically or not       |
 
 `texture properties`
 >Object to set the texture of the isometric path
@@ -956,6 +957,7 @@ removeEventListener(type, listener, [useCapture])
 | strokeLinejoin  | string             | Gets and sets the [SVG stroke linejoin][3] of the isometric path  |
 | strokeWidth     | number             | Gets and sets the stroke width of the isometric path              |
 | texture         | Texture (`object`) | Gets and sets the texture of the isometric path                   |
+| autoclose       | boolean            | Gets and sets the autoclose property of the isometric path        |
 
 </p>
 </details>

--- a/src/@classes/public/IsometricCircle/IsometricCircle.ts
+++ b/src/@classes/public/IsometricCircle/IsometricCircle.ts
@@ -107,7 +107,8 @@ export class IsometricCircle extends IsometricShape {
             commands,
             this.data.centerX,
             this.data.centerY,
-            this.data.scale
+            this.data.scale,
+            true
         );
     }
 
@@ -181,7 +182,8 @@ export class IsometricCircle extends IsometricShape {
                         commands,
                         this.data.centerX,
                         this.data.centerY,
-                        this.data.scale
+                        this.data.scale,
+                        true
                     )
                 }
             );

--- a/src/@classes/public/IsometricPath/IsometricPath.ts
+++ b/src/@classes/public/IsometricPath/IsometricPath.ts
@@ -4,26 +4,37 @@ import {
     SVGPathAnimation,
     SVGAnimationObject
 } from '@types';
-import { IsometricGraphic, IsometricGraphicProps } from '@classes/abstract/IsometricGraphic';
+import { IsometricGraphic } from '@classes/abstract/IsometricGraphic';
 import {
     addSVGProperties,
     parseDrawCommands,
     getSVGPath,
     getTextureCorner
 } from '@utils/svg';
+import { IsometricPathProps } from './types';
 
 export class IsometricPath extends IsometricGraphic {
 
-    public constructor(props: IsometricGraphicProps = {}) {
+    public constructor(props: IsometricPathProps = {}) {
         // Exclude the next line from the coverage reports
         // Check https://github.com/microsoft/TypeScript/issues/13029
         super(props)/* istanbul ignore next */;
         this.commands = [];
+        this._autoclose = 'autoclose' in this.props
+            ? (this.props as IsometricPathProps).autoclose
+            : true;
     }
 
     private commands: CommandPoint[];
+    private _autoclose: boolean;
 
-    private getPathFromCommands = (commands: string): string => getSVGPath(parseDrawCommands(commands), this.data.centerX, this.data.centerY, this.data.scale);
+    private getPathFromCommands = (commands: string): string => getSVGPath(
+        parseDrawCommands(commands),
+        this.data.centerX,
+        this.data.centerY,
+        this.data.scale,
+        this._autoclose
+    );
 
     protected privateUpdateAnimations(): void {
         
@@ -55,6 +66,15 @@ export class IsometricPath extends IsometricGraphic {
 
     }
 
+    public get autoclose(): boolean {
+        return this._autoclose;
+    }
+
+    public set autoclose(value: boolean) {
+        this._autoclose = value;
+        this.update();
+    }
+
     public update(): IsometricPath {
         if (this.path.parentNode) {
             const corner = getTextureCorner(
@@ -64,7 +84,13 @@ export class IsometricPath extends IsometricGraphic {
                 this.data.scale
             );
             addSVGProperties(this.path, {
-                d: getSVGPath(this.commands, this.data.centerX, this.data.centerY, this.data.scale)
+                d: getSVGPath(
+                    this.commands,
+                    this.data.centerX,
+                    this.data.centerY,
+                    this.data.scale,
+                    this._autoclose
+                )
             });
             this.updatePatternTransform(corner);
             this.updateAnimations();        

--- a/src/@classes/public/IsometricPath/index.ts
+++ b/src/@classes/public/IsometricPath/index.ts
@@ -1,1 +1,2 @@
 export * from './IsometricPath';
+export { IsometricPathProps } from './types';

--- a/src/@classes/public/IsometricPath/types.ts
+++ b/src/@classes/public/IsometricPath/types.ts
@@ -1,0 +1,5 @@
+import { IsometricGraphicProps } from '@classes/abstract/IsometricGraphic';
+
+export interface IsometricPathProps extends IsometricGraphicProps {
+    autoclose?: boolean;
+}

--- a/src/@classes/public/IsometricRectangle/IsometricRectangle.ts
+++ b/src/@classes/public/IsometricRectangle/IsometricRectangle.ts
@@ -77,7 +77,8 @@ export class IsometricRectangle extends IsometricShape {
             commands,
             this.data.centerX,
             this.data.centerY,
-            this.data.scale
+            this.data.scale,
+            true
         );
     }
 
@@ -152,7 +153,8 @@ export class IsometricRectangle extends IsometricShape {
                         commands,
                         this.data.centerX,
                         this.data.centerY,
-                        this.data.scale
+                        this.data.scale,
+                        true
                     )
                 }
             );

--- a/src/@utils/svg.ts
+++ b/src/@utils/svg.ts
@@ -40,7 +40,13 @@ const getCommandsWithStart = (commands: CommandPoint[]): CommandPoint[] => {
         ];
 };
 
-export const getSVGPath = (commands: CommandPoint[], centerX: number, centerY: number, scale: number): string => {
+export const getSVGPath = (
+    commands: CommandPoint[],
+    centerX: number,
+    centerY: number,
+    scale: number,
+    autoclose: boolean
+): string => {
     const drawCommands = getCommandsWithStart(commands);
     const svgPaths = drawCommands.map((c: CommandPoint, index: number) => {
         const point = getPointFromIsometricPoint(centerX, centerY, c.point, scale);     
@@ -64,7 +70,8 @@ export const getSVGPath = (commands: CommandPoint[], centerX: number, centerY: n
         }
     });
     if (svgPaths.length) {
-        return `${svgPaths.join(' ').trim()}z`;
+        const pathEnd = autoclose ? 'z' : '';
+        return `${svgPaths.join(' ').trim()}${pathEnd}`;
     }
     return '';
 };
@@ -98,7 +105,12 @@ export const parseDrawCommands = (commands: string): CommandPoint[] => {
     return commandsArray;
 };
 
-export const translateCommandPoints = (commands: CommandPoint[], right: number, left: number, top: number): void => {
+export const translateCommandPoints = (
+    commands: CommandPoint[],
+    right: number,
+    left: number,
+    top: number
+): void => {
     commands.forEach((command: CommandPoint): void => {
         command.point.r += right;
         command.point.l += left;
@@ -160,7 +172,13 @@ export const getSVGProperty = (property: SVGAnimationProperties): SVGNativePrope
     }[property] as SVGNativeProperties;
 };
 
-export function addEventListenerToElement(element: SVGElement, listeners: Listener[], event: string, callback: VoidFunction, useCapture: boolean): void {
+export function addEventListenerToElement(
+    element: SVGElement,
+    listeners: Listener[],
+    event: string,
+    callback: VoidFunction,
+    useCapture: boolean
+): void {
     const listener = {
         fn: callback,
         fnBind: callback.bind(this)
@@ -169,7 +187,13 @@ export function addEventListenerToElement(element: SVGElement, listeners: Listen
     element.addEventListener(event, listener.fnBind, useCapture);
 }
 
-export function removeEventListenerFromElement(element: SVGElement, listeners: Listener[], event: string, callback: VoidFunction, useCapture: boolean): void {
+export function removeEventListenerFromElement(
+    element: SVGElement, 
+    listeners: Listener[], 
+    event: string,
+    callback: VoidFunction,
+    useCapture: boolean
+): void {
     let listener: Listener;
     listeners.find((ln: Listener, index: number): boolean => {
         if (ln.fn === callback) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,8 +9,8 @@ export {
     SVGRectangleAnimation,
     SVGCircleAnimation
 } from '@types';
-export { IsometricCanvas, IsometricCanvasProps } from '@classes/public/IsometricCanvas';
-export { IsometricPath } from '@classes/public/IsometricPath';
 export { IsometricGraphicProps } from '@classes/abstract/IsometricGraphic';
+export { IsometricCanvas, IsometricCanvasProps } from '@classes/public/IsometricCanvas';
 export { IsometricRectangle, IsometricRectangleProps } from '@classes/public/IsometricRectangle';
 export { IsometricCircle, IsometricCircleProps } from '@classes/public/IsometricCircle';
+export { IsometricPath, IsometricPathProps } from '@classes/public/IsometricPath';

--- a/tests/__snapshots__/snapshots.test.ts.snap
+++ b/tests/__snapshots__/snapshots.test.ts.snap
@@ -455,6 +455,46 @@ exports[`Snapshot tests Draw rectangles 1`] = `
 </div>
 `;
 
+exports[`Snapshot tests Paths without autoclose 1`] = `
+<div>
+  <svg
+    height="320px"
+    viewBox="0 0 500 320"
+    width="500px"
+  >
+    <rect
+      fill="#CCC"
+      height="320px"
+      width="500px"
+      x="0"
+      y="0"
+    />
+    <path
+      d="M250 160 L353.923 220 L250 280 L146.077 220z"
+      fill="white"
+      fill-opacity="1"
+      stroke="black"
+      stroke-dasharray=""
+      stroke-linecap="butt"
+      stroke-linejoin="round"
+      stroke-opacity="1"
+      stroke-width="1"
+    />
+    <path
+      d="M250 160 L353.923 220 L250 280 L146.077 220"
+      fill="white"
+      fill-opacity="1"
+      stroke="black"
+      stroke-dasharray=""
+      stroke-linecap="butt"
+      stroke-linejoin="round"
+      stroke-opacity="1"
+      stroke-width="1"
+    />
+  </svg>
+</div>
+`;
+
 exports[`Snapshot tests Remove animations 1`] = `
 <div>
   <svg

--- a/tests/properties.test.ts
+++ b/tests/properties.test.ts
@@ -206,6 +206,7 @@ describe('Test properties', (): void => {
         expect(path.strokeLinejoin).toBe('miter');
         expect(path.strokeOpacity).toBe(0.25);
         expect(path.strokeWidth).toBe(2);
+        expect(path.autoclose).toBeTruthy();
         
         expect(pathElement.getAttribute('fill')).toBe('#FFF');
         expect(pathElement.getAttribute('fill-opacity')).toBe('0.5');
@@ -215,6 +216,7 @@ describe('Test properties', (): void => {
         expect(pathElement.getAttribute('stroke-linejoin')).toBe('miter');
         expect(pathElement.getAttribute('stroke-opacity')).toBe('0.25');
         expect(pathElement.getAttribute('stroke-width')).toBe('2');
+        expect(pathElement.getAttribute('d').endsWith('z')).toBeTruthy();
 
         path.fillColor = '#000';
         path.fillOpacity = 1;
@@ -224,6 +226,7 @@ describe('Test properties', (): void => {
         path.strokeLinejoin = 'bevel';
         path.strokeOpacity = 0.75;
         path.strokeWidth = 1;
+        path.autoclose = false;
 
         expect(path.fillColor).toBe('#000');
         expect(path.fillOpacity).toBe(1);
@@ -233,6 +236,7 @@ describe('Test properties', (): void => {
         expect(path.strokeLinejoin).toBe('bevel');
         expect(path.strokeOpacity).toBe(0.75);
         expect(path.strokeWidth).toBe(1);
+        expect(path.autoclose).toBeFalsy();
         
         expect(pathElement.getAttribute('fill')).toBe('#000');
         expect(pathElement.getAttribute('fill-opacity')).toBe('1');
@@ -242,6 +246,7 @@ describe('Test properties', (): void => {
         expect(pathElement.getAttribute('stroke-linejoin')).toBe('bevel');
         expect(pathElement.getAttribute('stroke-opacity')).toBe('0.75');
         expect(pathElement.getAttribute('stroke-width')).toBe('1');
+        expect(pathElement.getAttribute('d').endsWith('z')).toBeFalsy();
         
     });
 

--- a/tests/snapshots.test.ts
+++ b/tests/snapshots.test.ts
@@ -148,6 +148,29 @@ describe('Snapshot tests', (): void => {
 
     });
 
+    it('Paths without autoclose', (): void => {
+
+        const isometric = new IsometricCanvas({
+            container,
+            backgroundColor: '#CCC',
+            scale: 120,
+            width: 500,
+            height: 320
+        });
+
+        const pathA = new IsometricPath();
+        const pathB = new IsometricPath({ autoclose: false });
+        const commands = 'M0 0 0 L1 0 0 L1 1 0 L0 1 0';
+        
+        pathA.draw(commands);
+        pathB.draw(commands);
+
+        isometric.addChildren(pathA, pathB);
+
+        expect(container).toMatchSnapshot();
+
+    });
+
     it('Draw curves with method aliases', (): void => {
 
         const cube = new IsometricCanvas({


### PR DESCRIPTION
This pull request adds a new property to the options of the `IsometricPath` class to control if the path element of the `IsometricPath` should be closed automatically or not.

```typescript
{
    autoclose?: true
}
```

> Note: this property will be `true` by default.