### PR TITLE
Add reference comments to make the bundles provide types for Deno

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [3.2.1] - 2022-04-15
+
+- Bundle the types of the package in a single file
+- Add a triple-slash reference directive at the beginning of the bundles to enable types in Deno
+
 ## [3.2.0] - 2021-12-28
 
 - Added a property to close automatically or not the `IsometricPath`

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,6 +2,8 @@ import pkg from './package.json';
 import ts from 'rollup-plugin-ts';
 import { terser } from "rollup-plugin-terser";
 
+const reference = '/// <reference types="./index.d.ts" />';
+const esmReference = '/// <reference types="../index.d.ts" />';
 const banner = `
 var dom = new jsdom.JSDOM('<!DOCTYPE html><html><body></body></html>');
 var document = dom.window.document;
@@ -11,7 +13,7 @@ const getPlugins = () => [
     ts(),
     terser({
         output: {
-            comments: false
+            comments: /reference/
         }
     })
 ];
@@ -26,8 +28,16 @@ export default [
                 format: 'iife',
                 name: 'isometric'
             },
-            { file: pkg.main, format: 'cjs' },
-            { file: pkg.module, format: 'es' }
+            {
+                file: pkg.main,
+                format: 'cjs',
+                banner: reference
+            },
+            {
+                file: pkg.module,
+                format: 'es',
+                banner: esmReference
+            }
         ]
     },
     {
@@ -38,6 +48,7 @@ export default [
                 file: pkg.exports['./node'].require,
                 format: 'cjs',
                 banner: `
+                ${reference}
                 var jsdom = require('jsdom');
                 ${banner}
                 `
@@ -46,6 +57,7 @@ export default [
                 file: pkg.exports['./node'].import,
                 format: 'es',
                 banner: `
+                ${esmReference}
                 import jsdom from 'jsdom';
                 ${banner}
                 `


### PR DESCRIPTION
This pull request adds a triple-slash reference directive at the beginning of the bundles to make Deno projects importing the package get its types.