### PR TITLE
Capturing drag events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [3.6.0] - 2022-07-03
+
+- Capture drag events and possibility of preventing the the drag event modifies the coordinates of the element using `preventDefault` on `drag` event
+
 ## [3.5.1] - 2022-07-02
 
 - Restore the `dist/web/isometric.js` file that was ignored in gitignore by a mistake

--- a/src/@classes/abstract/IsometricDraggable/constants.ts
+++ b/src/@classes/abstract/IsometricDraggable/constants.ts
@@ -2,3 +2,9 @@ export const NO_LIMITS = [
     Number.MIN_SAFE_INTEGER,
     Number.MAX_SAFE_INTEGER
 ] as const;
+
+export enum DRAG_EVENT {
+    DRAG_START = 'dragstart',
+    DRAG = 'drag',
+    DRAG_END = 'dragend'
+}

--- a/src/@classes/abstract/IsometricElement/IsometricElement.ts
+++ b/src/@classes/abstract/IsometricElement/IsometricElement.ts
@@ -1,4 +1,7 @@
-import { Listener } from '@types';
+import {
+    Listener,
+    AddEventListenerCallback
+} from '@types';
 import {
     SVG_NAMESPACE,
     SVG_ELEMENTS
@@ -30,12 +33,12 @@ export abstract class IsometricElement extends IsometricStore {
         return this.element;
     }
 
-    public addEventListener(event: string, callback: VoidFunction, useCapture = false): this {
+    public addEventListener(event: string, callback: AddEventListenerCallback, useCapture = false): this {
         addEventListenerToElement.call(this, this.element, this.listeners, event, callback, useCapture);
         return this;
     }
 
-    public removeEventListener(event: string, callback: VoidFunction, useCapture = false): this {
+    public removeEventListener(event: string, callback: AddEventListenerCallback, useCapture = false): this {
         removeEventListenerFromElement(this.element, this.listeners, event, callback, useCapture);
         return this;
     }

--- a/src/@types/type-modules/generic.ts
+++ b/src/@types/type-modules/generic.ts
@@ -1,5 +1,7 @@
 export type StringOrNumber = string | number;
 
+export type AddEventListenerCallback = (event?: Event) => void;
+
 type RequestAnimationFrame = typeof window.requestAnimationFrame;
 
 declare global {
@@ -8,4 +10,4 @@ declare global {
         webkitRequestAnimationFrame: RequestAnimationFrame;
         msRequestAnimationFrame: RequestAnimationFrame;
     }
-  }
+}

--- a/src/@utils/svg.ts
+++ b/src/@utils/svg.ts
@@ -7,6 +7,7 @@ import {
     SVGAnimationProperties,
     SVGNativeProperties,
     SVGProps,
+    AddEventListenerCallback
 } from '@types';
 import {
     COMMANDS_REGEXP,
@@ -176,7 +177,7 @@ export function addEventListenerToElement(
     element: SVGElement,
     listeners: Listener[],
     event: string,
-    callback: VoidFunction,
+    callback: AddEventListenerCallback,
     useCapture: boolean
 ): void {
     const listener = {
@@ -191,7 +192,7 @@ export function removeEventListenerFromElement(
     element: SVGElement, 
     listeners: Listener[], 
     event: string,
-    callback: VoidFunction,
+    callback: AddEventListenerCallback,
     useCapture: boolean
 ): void {
     let listener: Listener;

--- a/tests/drag.test.ts
+++ b/tests/drag.test.ts
@@ -60,7 +60,7 @@ const dragElementWithTouchEvents = async (element: SVGElement, x: number, y: num
 
 };
 
-describe('Test properties', (): void => {
+describe('Test dragging', (): void => {
 
     let spy: jest.SpyInstance<number, [callback: FrameRequestCallback]>;
     let container: HTMLDivElement;
@@ -336,6 +336,84 @@ describe('Test properties', (): void => {
         expect(group.left).toBe(0);
         expect(group.top).toBe(-3.811957);
         expect(groupElement.getAttribute('transform')).toBe('translate(799.999999, 500)');
+
+    });
+
+    it('Capturing drag events', async (): Promise<void> => {
+        
+        const mockDragstart = jest.fn();
+        const mockDrag = jest.fn();
+        const mockEnd = jest.fn();
+        
+        group.drag = PlaneView.TOP;
+
+        group.addEventListener('dragstart', mockDragstart);
+        group.addEventListener('drag', mockDrag);
+        group.addEventListener('dragend', mockEnd);
+
+        await dragElement(groupElement, 200, 300);
+
+        expect(mockDragstart).toBeCalledTimes(1);
+        expect(mockDragstart.mock.calls[0][0].detail.right).toBe(41.547011);
+        expect(mockDragstart.mock.calls[0][0].detail.left).toBe(18.452989);
+        expect(mockDragstart.mock.calls[0][0].detail.top).toBe(0);
+
+        expect(mockDrag).toBeCalledTimes(1);
+        expect(mockDrag.mock.calls[0][0].detail.right).toBe(41.547011);
+        expect(mockDrag.mock.calls[0][0].detail.left).toBe(18.452989);
+        expect(mockDrag.mock.calls[0][0].detail.top).toBe(0);
+
+        expect(mockEnd).toBeCalledTimes(1);
+        expect(mockEnd.mock.calls[0][0].detail.right).toBe(41.547011);
+        expect(mockEnd.mock.calls[0][0].detail.left).toBe(18.452989);
+        expect(mockEnd.mock.calls[0][0].detail.top).toBe(0);
+
+        group.removeEventListener('dragstart', mockDragstart);
+        group.removeEventListener('drag', mockDrag);
+        group.removeEventListener('dragend', mockEnd);
+
+        await dragElement(groupElement, 300, 200);
+
+        expect(mockDragstart).toBeCalledTimes(1);
+        expect(mockDrag).toBeCalledTimes(1);
+        expect(mockEnd).toBeCalledTimes(1);
+
+    });
+
+    it('Preventing dragging', async (): Promise<void> => {
+        
+        const mockDragstart = jest.fn();
+        const mockDrag = jest.fn((event: CustomEvent) => {
+            event.preventDefault();
+        });
+        const mockEnd = jest.fn();
+        
+        group.drag = PlaneView.TOP;
+
+        group.addEventListener('dragstart', mockDragstart);
+        group.addEventListener('drag', mockDrag);
+        group.addEventListener('dragend', mockEnd);
+
+        await dragElement(groupElement, 200, 300);
+
+        expect(mockDragstart).toBeCalledTimes(1);
+        expect(mockDragstart.mock.calls[0][0].detail.right).toBe(41.547011);
+        expect(mockDragstart.mock.calls[0][0].detail.left).toBe(18.452989);
+        expect(mockDragstart.mock.calls[0][0].detail.top).toBe(0);
+
+        expect(mockDrag).toBeCalledTimes(1);
+        expect(mockDrag.mock.calls[0][0].detail.right).toBe(41.547011);
+        expect(mockDrag.mock.calls[0][0].detail.left).toBe(18.452989);
+        expect(mockDrag.mock.calls[0][0].detail.top).toBe(0);
+
+        expect(mockEnd).toBeCalledTimes(1);
+        expect(mockEnd.mock.calls[0][0].detail.right).toBe(41.547011);
+        expect(mockEnd.mock.calls[0][0].detail.left).toBe(18.452989);
+        expect(mockEnd.mock.calls[0][0].detail.top).toBe(0);
+
+        expect(group.right).toBe(0);
+        expect(group.left).toBe(0);
+        expect(group.top).toBe(0);
 
     });
 


### PR DESCRIPTION
Now, it is possible to capture drag events and prevent the main drag event to modify the element coordinates.

```
const element = new IsometricGroup();

cube.drag = 'TOP';

cube.addEventListener('dragstart', function(event) {
    console.log(event.detail.right);
    console.log(event.detail.left);
    console.log(event.detail.top);
});

cube.addEventListener('drag', function(event) {
    if(event.detail.right > 10) {
        this.right = 10;
        event.preventDefault();
    }
});

cube.addEventListener('dragend', function() {
    console.log('the drag process has been ended');
});
```