### PR TITLE
Fix ESM types

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -84,5 +84,6 @@ jobs:
             esm/index.js
             esm/index.node.js
             index.d.ts
+            node.d.ts
           body: |
             ${{ steps.build_changelog.outputs.changelog }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [3.7.3] - 2023-08-12
+
+- Fix ESM types
+
 ## [3.7.2] - 2023-03-27
 
 - Fix a getter with a different type from the setter

--- a/package.json
+++ b/package.json
@@ -7,12 +7,24 @@
   "types": "index.d.ts",
   "exports": {
     ".": {
-      "require": "./index.js",
-      "import": "./esm/index.js"
+      "require": {
+        "types": "./index.d.ts",
+        "default": "./index.js"
+      },
+      "import": {
+        "types": "./esm/index.d.ts",
+        "default": "./esm/index.js"
+      }
     },
     "./node": {
-      "require": "./index.node.js",
-      "import": "./esm/index.node.js"
+      "require": {
+        "types": "./node.d.ts",
+        "default": "./index.node.js"
+      },
+      "import": {
+        "types": "./esm/node.d.ts",
+        "default": "./esm/index.node.js"
+      }
     }
   },
   "files": [

--- a/scripts/finish.sh
+++ b/scripts/finish.sh
@@ -2,8 +2,7 @@
 
 mkdir -p dist/web/
 
-rm esm/index.d.ts
-rm esm/index.node.d.ts
+mv esm/index.node.d.ts esm/node.d.ts
 rm web/isometric.d.ts
 cp web/isometric.js dist/web/isometric.js
 mv index.node.d.ts node.d.ts


### PR DESCRIPTION
Following the recommendations in the [TypeScript Handbook](https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing). This is to avoid `TypeScript` complaining about missing types when the ESM module is used:

>Could not find a declaration file for module '@elchininet/isometric'. '/path-to-project/node_modules/@elchininet/isometric/esm/index.js' implicitly has an 'any' type.
  There are types at '/path-to-project/node_modules/@elchininet/isometric/index.d.ts', but this result could not be resolved when respecting package.json "exports". The '@elchininet/isometric' library may need to update its package.json or typings.ts(7016)