### PR TITLE
Replace some logical OR by nullish coalescing operators

### DIFF
--- a/src/@classes/abstract/IsometricDraggableAbstract/IsometricDraggableAbstract.ts
+++ b/src/@classes/abstract/IsometricDraggableAbstract/IsometricDraggableAbstract.ts
@@ -20,6 +20,7 @@ import {
     IsometricDraggableProps,
     Drag,
     Boundaries,
+    Bounds,
     ClientCoords
 } from './types';
 
@@ -102,8 +103,15 @@ export abstract class IsometricDraggableAbstract extends IsometricElementAbstrac
         );
     }
 
+    private getBoundOrMaximum(prop: 'right' | 'left' | 'top'): Bounds {
+        if (this.bounds) {
+            return this.bounds[prop] ?? [ ...NO_LIMITS ];
+        }
+        return [ ...NO_LIMITS ];
+    }
+
     private getRight(value: number): number {
-        const bounds = this._bounds && this._bounds.right || NO_LIMITS;
+        const bounds = this.getBoundOrMaximum('right');
         return this.betweenBounds(
             this._dragStore.right + value / this.data.scale,
             bounds
@@ -111,7 +119,7 @@ export abstract class IsometricDraggableAbstract extends IsometricElementAbstrac
     }
 
     private getLeft(value: number): number {
-        const bounds = this._bounds && this._bounds.left || NO_LIMITS;
+        const bounds = this.getBoundOrMaximum('left');
         return this.betweenBounds(
             this._dragStore.left + value / this.data.scale,
             bounds,
@@ -119,7 +127,7 @@ export abstract class IsometricDraggableAbstract extends IsometricElementAbstrac
     }
 
     private getTop(value: number): number {
-        const bounds = this._bounds && this._bounds.top || NO_LIMITS;
+        const bounds = this.getBoundOrMaximum('top');
         return this.betweenBounds(
             this._dragStore.top + value / this.data.scale,
             bounds
@@ -149,9 +157,9 @@ export abstract class IsometricDraggableAbstract extends IsometricElementAbstrac
             {
                 cancelable: eventType === DRAG_EVENT.DRAG,
                 detail: {
-                    right: this._coords.right || this.right,
-                    left: this._coords.left || this.left,
-                    top: this._coords.top || this.top
+                    right: this._coords.right ?? this.right,
+                    left: this._coords.left ?? this.left,
+                    top: this._coords.top ?? this.top
                 }
             }
         );
@@ -318,9 +326,9 @@ export abstract class IsometricDraggableAbstract extends IsometricElementAbstrac
 
     public set bounds(value: Boundaries) {
         this._bounds = value;
-        const boundsRight = this._bounds && this._bounds.right || NO_LIMITS;
-        const boundsLeft = this._bounds && this._bounds.left || NO_LIMITS;
-        const boundsTop = this._bounds && this._bounds.top || NO_LIMITS;
+        const boundsRight = this.getBoundOrMaximum('right');
+        const boundsLeft = this.getBoundOrMaximum('left');
+        const boundsTop = this.getBoundOrMaximum('top');
         this.right = this.betweenBounds(this.right, boundsRight);
         this.left = this.betweenBounds(this.left, boundsLeft);
         this.top = this.betweenBounds(this.top, boundsTop);

--- a/src/@classes/abstract/IsometricStarPolygonAbstract/IsometricStarPolygonAbstract.ts
+++ b/src/@classes/abstract/IsometricStarPolygonAbstract/IsometricStarPolygonAbstract.ts
@@ -56,13 +56,13 @@ export abstract class IsometricStarPolygonAbstract extends IsometricShapeAbstrac
     protected _halfSector: number;
 
     protected getCommands(args?: GetStarPolygonAbstractPathArguments): CommandPoint[] {
-        const right = args?.right || this.right;
-        const left = args?.left || this.left;
-        const top = args?.top || this.top;
-        const radius = args?.radius || this.radius;
-        const points = args?.points || this._points;
-        const density = args?.density || this._density;
-        const rotation = args?.rotation || this.rotation;
+        const right = args?.right ?? this.right;
+        const left = args?.left ?? this.left;
+        const top = args?.top ?? this.top;
+        const radius = args?.radius ?? this.radius;
+        const points = args?.points ?? this._points;
+        const density = args?.density ?? this._density;
+        const rotation = args?.rotation ?? this.rotation;
         const coordinates = this.get2DCoordinates(
             radius,
             points,

--- a/src/@classes/public/IsometricCircle/IsometricCircle.ts
+++ b/src/@classes/public/IsometricCircle/IsometricCircle.ts
@@ -37,10 +37,10 @@ export class IsometricCircle extends IsometricShapeAbstract {
     private _radius: number;
 
     protected getCommands(args?: GetCirclePathArguments): CommandPoint[] {
-        const right = args?.right || this.right;
-        const left = args?.left || this.left;
-        const top = args?.top || this.top;
-        const radius = args?.radius || this.radius;
+        const right = args?.right ?? this.right;
+        const left = args?.left ?? this.left;
+        const top = args?.top ?? this.top;
+        const radius = args?.radius ?? this.radius;
         const commands: CommandPoint[] = [];
         switch(this.planeView) {
             case PlaneView.FRONT:

--- a/src/@classes/public/IsometricRectangle/IsometricRectangle.ts
+++ b/src/@classes/public/IsometricRectangle/IsometricRectangle.ts
@@ -40,11 +40,11 @@ export class IsometricRectangle extends IsometricShapeAbstract {
     private _height: number;
 
     protected getCommands(args?: GetRectanglePathArguments): CommandPoint[] {
-        const right = args?.right || this.right;
-        const left = args?.left || this.left;
-        const top = args?.top || this.top;
-        const width = args?.width || this.width;
-        const height = args?.height || this.height;
+        const right = args?.right ?? this.right;
+        const left = args?.left ?? this.left;
+        const top = args?.top ?? this.top;
+        const width = args?.width ?? this.width;
+        const height = args?.height ?? this.height;
         const commands: LinePoint[] = [ {command: Command.move, point: {r: 0, l: 0, t: 0}} ];
         switch(this.planeView) {
             case PlaneView.FRONT:


### PR DESCRIPTION
Some values were taking their default values using logical OR operators, something that made to take the default value if the assigned value was `0`. This pull request replaces those logical OR operators by nullish coalescing ones to avoid this behaviour.