### PR TITLE
Configure Dependabot to update Github actionss

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,14 @@ updates:
     labels:
       - dependencies
     versioning-strategy: increase
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+      time: "09:00"
+      timezone: "Europe/Amsterdam"
+    commit-message:
+      prefix: "[Github Actions]"
+    labels:
+      - configuration


### PR DESCRIPTION
This pull request configures Dependabot to update Github actions.