### PR TITLE
Specify a specific pnpm version in engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,8 @@
     "webpack-dev-server": "^5.2.2"
   },
   "engines": {
-    "node": ">=12.22.0"
+    "node": ">=12.22.0",
+    "pnpm": ">=10.17.0"
   },
   "dependencies": {
     "jsdom": "^26.1.0"


### PR DESCRIPTION
Dependabot is using an outdated `pnpm` version (`10.14.0`) and it fails with an error that [should not exist in the latest pnpm versions](https://github.com/pnpm/pnpm/issues/9361#issuecomment-2915368247). This pull request adds a specific `pnpm` version to engines to see if this fixes the issue.