### PR TITLE
Removing pnpm constraint

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,8 +102,7 @@
     "webpack-dev-server": "^5.2.2"
   },
   "engines": {
-    "node": ">=12.22.0",
-    "pnpm": ">=10.17.0"
+    "node": ">=12.22.0"
   },
   "dependencies": {
     "jsdom": "^26.1.0"


### PR DESCRIPTION
In [this pull request](https://github.com/elchininet/isometric/pull/266) a constraint of `pnpm` was added trying to solve an issue of dependabot installing an old version of `pnpm`. This didn't solve the issue, [dependabot keeps installing an old version even if it detects the constraint](https://github.com/elchininet/isometric/actions/runs/17986941374/job/51167412191).

This is probably the same as [this issue](https://github.com/dependabot/dependabot-core/issues/13045).

```bash
updater | 2025/09/24 19:09:47 INFO <job_1107990638> Guessed version info "pnpm" : "9"
2025/09/24 19:09:47 INFO <job_1107990638> Installed version for pnpm: 10.14.0
2025/09/24 19:09:47 INFO <job_1107990638> Processing engine constraints for pnpm
2025/09/24 19:09:47 INFO <job_1107990638> Parsed constraints for pnpm: >=10.17.0
2025/09/24 19:09:47 INFO <job_1107990638> Version requirement for pnpm: >= 10.17.0
2025/09/24 19:09:47 INFO <job_1107990638> Returned (engines) info "pnpm" : ""
2025/09/24 19:09:47 INFO <job_1107990638> Guessed version info "pnpm" : "9"
2025/09/24 19:09:47 INFO <job_1107990638> Installing "pnpm@9"
updater | 2025/09/24 19:09:47 INFO <job_1107990638> Started process PID: 1532 with command: {} corepack install pnpm@9 --global --cache-only {}
```