### PR TITLE
Add an empty packages array to pnpm-workspace.yaml

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
 overrides:
   '@eslint/plugin-kit@<0.3.4': '>=0.3.4'
   on-headers@<1.1.0: '>=1.1.0'
+packages:
+  - .


### PR DESCRIPTION
Dependabot is installing an outdated version of `pnpm` that is not compatible with the repository settings and this makes the dependabot job to fail. Even adding a `pnpm` constraint, doesn't solve the issue. This merge request adds a temporary empty `packages` array to avoid the next error under `pnpm@9`:

```bash
ERROR  packages field missing or empty
```

This hack should be removed when [this issue](https://github.com/dependabot/dependabot-core/issues/13045) gets solved.