### PR TITLE
Move pnpm overrides to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,5 +106,11 @@
   },
   "dependencies": {
     "jsdom": "^26.1.0"
+  },
+  "pnpm": {
+    "overrides": {
+      "@eslint/plugin-kit@<0.3.4": ">=0.3.4",
+      "on-headers@<1.1.0": ">=1.1.0"
+    }
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,0 @@
-overrides:
-  '@eslint/plugin-kit@<0.3.4': '>=0.3.4'
-  on-headers@<1.1.0: '>=1.1.0'
-packages:
-  - .


### PR DESCRIPTION
This is a second intent to solve [a dependabot issue](https://github.com/elchininet/isometric/pull/268) that is using an old `pnpm` version. Adding an empty `packages` array solves the issue of dependabot not creating the pull requests, but then it created a second issue, because PRs fail with this error:

```bash
ERR_PNPM_LOCKFILE_CONFIG_MISMATCH  Cannot proceed with the frozen installation. The current "overrides" configuration doesn't match the value found in the lockfile
```

To avoid this, the `pnpm-workspace.yaml` file was removed altogether and the `overrides` were moved to the `package.json` file.