### PR TITLE
Fix a bug of an error being thrown if a property is set in a group that has no parent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [3.11.2] - 2025-09-24
+
+- Avoid updating a group that has not been added to a canvas. This will avoid an error if a property is set before the group has been added to a canvas.
+
 ## [3.11.1] - 2025-01-01
 
 - Created a utility to build animation properties and refactored the classes to make use of this utility to avoid code repetition

--- a/src/@classes/public/IsometricGroup/IsometricGroup.ts
+++ b/src/@classes/public/IsometricGroup/IsometricGroup.ts
@@ -1,6 +1,6 @@
 import { SVG_ELEMENTS } from '@constants';
 import { uuid, getPointFromIsometricPoint } from '@utils/math';
-import { addSVGProperties } from '@utils/svg';
+import { addSVGProperties, elementHasSVGParent } from '@utils/svg';
 import { applyMixins } from '@utils/other';
 import { IsometricContainerAbstract } from '@classes/abstract/IsometricContainerAbstract';
 import { IsometricDraggableAbstract } from '@classes/abstract/IsometricDraggableAbstract';
@@ -28,22 +28,24 @@ export class IsometricGroup extends IsometricContainerAbstract {
     protected props: IsometricGroupProps;
 
     public override update(): this {
-        const point = getPointFromIsometricPoint(
-            0,
-            0,
-            {
-                r: this.props.right,
-                l: this.props.left,
-                t: this.props.top
-            },
-            this.data.scale
-        );
-        addSVGProperties(
-            this.element,
-            {
-                transform: `translate(${point.x}, ${point.y})`
-            }
-        );
+        if (elementHasSVGParent(this.element)) {
+            const point = getPointFromIsometricPoint(
+                0,
+                0,
+                {
+                    r: this.props.right,
+                    l: this.props.left,
+                    t: this.props.top
+                },
+                this.data.scale
+            );
+            addSVGProperties(
+                this.element,
+                {
+                    transform: `translate(${point.x}, ${point.y})`
+                }
+            );
+        }
         return super.update();
     }
 

--- a/tests/properties.test.ts
+++ b/tests/properties.test.ts
@@ -649,4 +649,14 @@ describe('Test properties', (): void => {
 
     });
 
+    it('IsometricGroup properties without being adding to canvas', () => {
+        const group = new IsometricGroup();
+        group.top = 1;
+        group.right = 0.5;
+        group.left = 2;
+        expect(group.top).toBe(1);
+        expect(group.right).toBe(0.5);
+        expect(group.left).toBe(2);
+    });
+
 });


### PR DESCRIPTION
Setting a property in a group without parent was throwing an error.

<img width="517" height="98" alt="image" src="https://github.com/user-attachments/assets/ac8899be-6b92-49e0-963f-82c4128fb7e8" />
