### PR TITLE
Set cooldown period for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
       day: "sunday"
       time: "09:00"
       timezone: "Europe/Amsterdam"
+    cooldown:
+      default-days: 1
     commit-message:
       prefix: "[Dependencies]"
     groups:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,7 +1,5 @@
 allowBuilds:
   '@parcel/watcher': false
   unrs-resolver: false
-minimumReleaseAgeExclude:
-  - postcss@8.5.10
 overrides:
   postcss@<8.5.10: ^8.5.10


### PR DESCRIPTION
This pull request sets [a cooldown period](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-) in the Depndabot configuration to avoid the `pnpm` `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION` error because Dependabot updates packages that have been released before the `pnpm` minimum release age.